### PR TITLE
Improve variable names

### DIFF
--- a/analytics/analytics-server/src/main/solution/delays/java/stream/task/DelayRatioTask.java
+++ b/analytics/analytics-server/src/main/solution/delays/java/stream/task/DelayRatioTask.java
@@ -38,17 +38,19 @@ public class DelayRatioTask implements ServerTask {
       Cache<String, Stop> cache = getCache();
 
       Map<Integer, Long> totalPerHour = cache.values().stream()
-         .collect(() -> Collectors.groupingBy(
-            e -> getHourOfDay(e.departureTs),
-            Collectors.counting()
-         ));
+         .collect( () ->
+            Collectors.groupingBy(
+               stop -> getHourOfDay( stop.departureTs ),
+               Collectors.counting() )
+         );
 
       Map<Integer, Long> delayedPerHour = cache.values().stream()
-         .filter(e -> e.delayMin > 0)
-         .collect(() -> Collectors.groupingBy(
-            e -> getHourOfDay(e.departureTs),
-            Collectors.counting()
-         ));
+         .filter( stop -> stop.delayMin > 0 )
+         .collect( () ->
+            Collectors.groupingBy(
+               stop -> getHourOfDay( stop.departureTs ),
+               Collectors.counting() )
+         );
 
       return Arrays.asList(delayedPerHour, totalPerHour);
    }

--- a/real-time/real-time-vertx/src/main/solution/delays/query/continuous/ContinuousQueryVerticle.java
+++ b/real-time/real-time-vertx/src/main/solution/delays/query/continuous/ContinuousQueryVerticle.java
@@ -39,14 +39,17 @@ public class ContinuousQueryVerticle extends AbstractVerticle {
       stationBoards = client.getCache("default");
       QueryFactory qf = Search.getQueryFactory(stationBoards);
 
-      //TODO write query
-      Query query = null;
+      Query query = qf.from( StationBoard.class )
+         .having("entries.delayMin").gt( 0L )
+         .build();
 
       ContinuousQueryListener<Station, StationBoard> listener =
             new ContinuousQueryListener<Station, StationBoard>() {
                @Override
                public void resultJoining(Station station, StationBoard stationBoard) {
-                  //TODO work on station board
+                  stationBoard.entries.stream()
+                     .filter( stop -> stop.delayMin > 0 )
+                     .forEach( stop -> publishDelay( station, stop  ) );
                }
 
                @Override


### PR DESCRIPTION
Short names like "s" are confusing to the presentation reader
Likewise for, generic names like "key"
I made the name explicit in the code.